### PR TITLE
Fix environment version check

### DIFF
--- a/packages/backend/src/server-env.ts
+++ b/packages/backend/src/server-env.ts
@@ -3,7 +3,7 @@ import { isServer } from "./utils/environment-utils"
 export const GITHUB_CI = isServer && process.env.GITHUB_CI === "true"
 export const APP_VERSION = isServer && extractVersion(process.env.APP_VERSION)
 
-function extractVersion(version: string) {
+function extractVersion(version = "") {
   try {
     const raw = version.split("\n")[0]
 


### PR DESCRIPTION
## Summary
- avoid crash when APP_VERSION env var is undefined

## Testing
- `yarn test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687292d424548333a7e4ea6bd7fb8ba5